### PR TITLE
feat: Add output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,27 @@ This configuration will use the same naming, but place all binaries in a `bin/` 
 An `output` configuration must have all three `${TARGET}`, `${GOOS}`, `${GOARCH}`
 placeholders present, but the ordering can change.
 
-Windows, as a special case, will always have ".exe" appended to the filename.
+Windows, as a special case, will always have ".exe" appended to the filename of a raw binary.
 
 The `TARGET` placeholder expands to the default build target name that `go build` would produce.
 The `GOOS` placeholder is expands to the `GOOS` under build.
 The `GOARCH` placeholder expands to the `GOARCH` under build.
 
 Only a single `output` directive may be found in a package.
+
+## Output formats
+
+multibuild can produce several types of output.
+
+`//go:multibuild:format=raw,zip,tar.gz`
+
+The list of formats is comma separated, and any of the following are supported:
+
+* `raw` - The default, the raw binary produced by `go build`.
+* `zip` - A zip archive of the raw binary.
+* `tar.gz` - A tar.gz'd archive of the raw binary.
+
+Only a single `format` directive may be found in a package.
 
 # Differences to `go build`
 

--- a/cmd/multibuild/main.go
+++ b/cmd/multibuild/main.go
@@ -31,6 +31,7 @@ func displayConfigAndExit(opts options) {
 	fmt.Fprintf(os.Stderr, "//go:multibuild:include=%s\n", strings.Join(mapSlice(opts.Include, func(f filter) string { return string(f) }), ","))
 	fmt.Fprintf(os.Stderr, "//go:multibuild:exclude=%s\n", strings.Join(mapSlice(opts.Exclude, func(f filter) string { return string(f) }), ","))
 	fmt.Fprintf(os.Stderr, "//go:multibuild:output=%s\n", opts.Output)
+	fmt.Fprintf(os.Stderr, "//go:multibuild:format=%s\n", strings.Join(mapSlice(opts.Format, func(f format) string { return string(f) }), ","))
 	os.Exit(0)
 }
 

--- a/cmd/multibuild/options_test.go
+++ b/cmd/multibuild/options_test.go
@@ -511,3 +511,88 @@ func TestValidateFilters_Invalid(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateFormatString(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		outputs []format
+	}{
+		{
+			name:    "single (raw)",
+			input:   "raw",
+			wantErr: false,
+			outputs: []format{formatRaw},
+		},
+		{
+			name:    "single (zip)",
+			input:   "zip",
+			wantErr: false,
+			outputs: []format{formatZip},
+		},
+		{
+			name:    "single (tgz)",
+			input:   "tar.gz",
+			wantErr: false,
+			outputs: []format{formatTgz},
+		},
+		{
+			name:    "all",
+			input:   "raw,zip,tar.gz",
+			wantErr: false,
+			outputs: []format{formatRaw, formatZip, formatTgz},
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+			outputs: []format{},
+		},
+		{
+			name:    "all-unknown",
+			input:   "wat",
+			wantErr: true,
+			outputs: []format{},
+		},
+		{
+			name:    "partly-unknown",
+			input:   "zip,wat",
+			wantErr: true,
+			outputs: []format{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := validateFormatString(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (output=%v)", out)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			equalFormats := func(a, b []format) bool {
+				if len(a) != len(b) {
+					return false
+				}
+				for i := range a {
+					if a[i] != b[i] {
+						return false
+					}
+				}
+				return true
+			}
+
+			if !equalFormats(out, tt.outputs) {
+				t.Fatalf("output mismatch: got %q, want %q", out, tt.input)
+			}
+		})
+	}
+}

--- a/cmd/multibuild/options_test.go
+++ b/cmd/multibuild/options_test.go
@@ -180,18 +180,11 @@ func TestScanBuildPath(t *testing.T) {
 	}
 
 	equalOptions := func(a, b options) bool {
-		if len(a.Include) != len(b.Include) || len(a.Exclude) != len(b.Exclude) {
+		if !slices.Equal(a.Include, b.Include) {
 			return false
 		}
-		for i := range a.Include {
-			if a.Include[i] != b.Include[i] {
-				return false
-			}
-		}
-		for i := range a.Exclude {
-			if a.Exclude[i] != b.Exclude[i] {
-				return false
-			}
+		if !slices.Equal(a.Exclude, b.Exclude) {
+			return false
 		}
 		return true
 	}
@@ -578,19 +571,7 @@ func TestValidateFormatString(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			equalFormats := func(a, b []format) bool {
-				if len(a) != len(b) {
-					return false
-				}
-				for i := range a {
-					if a[i] != b[i] {
-						return false
-					}
-				}
-				return true
-			}
-
-			if !equalFormats(out, tt.outputs) {
+			if !slices.Equal(out, tt.outputs) {
 				t.Fatalf("output mismatch: got %q, want %q", out, tt.input)
 			}
 		})


### PR DESCRIPTION
Remaining work:

- [x] Add tests for validateFormatString
- [x] Add integration tests for `format=`
- [x] Error handling during archiving is presently nonexistent
- [x] FIXME: archive naming case under Windows
- [x] FIXME: remove raw if we don't want to keep it
- [x] Permissions on binary in tgz need fixing
- [ ] Consider tidying up scanBuildPath, duplication is getting a little gnarly - but maybe for a subsequent PR

Note that bzip2 is not part of this at present. I'd like to add it, but https://github.com/golang/go/issues/4828 is a problem. I guess we could shell out, but that seems suboptimal (supply chain security, build reproducibility, ...)